### PR TITLE
DEVIDM-73: addMailLocalAddress rewrite.

### DIFF
--- a/src/main/groovy/se/su/it/svc/AccountServiceImpl.groovy
+++ b/src/main/groovy/se/su/it/svc/AccountServiceImpl.groovy
@@ -367,26 +367,17 @@ public class AccountServiceImpl implements AccountService {
         audit: audit ]) &&
     mailLocalAddresses?.size() > 0
   })
-  public String[] addMailLocalAddresses(@WebParam(name = 'uid') String uid,
-                                        @WebParam(name='mailLocalAddresses') String[] mailLocalAddresses,
-                                        @WebParam(name="audit") SvcAudit audit) {
+  public String[] addMailLocalAddresses(@WebParam(name = "uid") String uid,
+                                        @WebParam(name = "mailLocalAddresses") String[] mailLocalAddresses,
+                                        @WebParam(name = "audit") SvcAudit audit) {
 
     SuPerson suPerson = SuPersonQuery.getSuPersonFromUID(GldapoManager.LDAP_RW, uid)
     // Can't depend on the mailLocalAddress Set doing it's thing without removing case.
 
-    mailLocalAddresses = mailLocalAddresses*.toLowerCase()
-    if (suPerson.mailLocalAddress == null) {
-      suPerson.mailLocalAddress = [] as LinkedHashSet
-      suPerson.mailLocalAddress.addAll(mailLocalAddresses)
-    } else {
-      List newEntries = mailLocalAddresses - suPerson?.mailLocalAddress*.toLowerCase()
-      if (newEntries) {
-        suPerson.mailLocalAddress += newEntries
-      }
-    }
+    String[] mailLocalAddress = suPerson.addMailLocalAddress(mailLocalAddresses as Set<String>)
 
     suPerson.update()
 
-    return suPerson.mailLocalAddress
+    return mailLocalAddress
   }
 }

--- a/src/main/groovy/se/su/it/svc/ldap/SuPerson.groovy
+++ b/src/main/groovy/se/su/it/svc/ldap/SuPerson.groovy
@@ -347,4 +347,23 @@ class SuPerson implements Serializable {
     log.info("enrollUser - User with uid <$uid> now enabled.")
   }
 
+  /**
+   * Sets mailLocalAddress if not already set, adds new mailLocalAddress if
+   * @param mailLocalAddresses
+   */
+  public String[] addMailLocalAddress(Set<String> mailLocalAddresses) {
+
+    mailLocalAddresses = mailLocalAddresses*.toLowerCase()
+
+    if (mailLocalAddress == null) {
+      setMailLocalAddress(mailLocalAddresses)
+    } else {
+      def newEntries = mailLocalAddresses - mailLocalAddress*.toLowerCase()
+      if (newEntries) {
+        mailLocalAddress += newEntries
+      }
+    }
+
+    return mailLocalAddress as String[]
+  }
 }

--- a/src/test/groovy/se/su/it/svc/AccountServiceImplSpec.groovy
+++ b/src/test/groovy/se/su/it/svc/AccountServiceImplSpec.groovy
@@ -737,15 +737,17 @@ class AccountServiceImplSpec extends Specification {
     def mailLocalAddresses = ['kaka@su.se', "bar@su.se"]
     String uid = 'foo'
     def suPersonQueryMock = GroovyMock(SuPersonQuery, global:true)
-    SuPerson suPerson = new SuPerson()
+    SuPerson suPerson = GroovyMock(SuPerson)
     SuPersonQuery.getSuPersonFromUID(_, uid) >> suPerson
-
 
     when:
     def resp = service.addMailLocalAddresses(uid, mailLocalAddresses as String[], new SvcAudit())
 
     then:
     resp == mailLocalAddresses
+
+    and:
+    1 * suPerson.addMailLocalAddress(_) >> mailLocalAddresses
   }
 
   def "addMailLocalAddresses: When SuPerson"() {
@@ -754,14 +756,16 @@ class AccountServiceImplSpec extends Specification {
     def mailLocalAddresses = ['kaka@su.se', "bar@su.se"]
     String uid = 'foo'
     def suPersonQueryMock = GroovyMock(SuPersonQuery, global:true)
-    SuPerson suPerson = new SuPerson(mailLocalAddress: ["barbar@su.se", "kaka@su.se"])
+    SuPerson suPerson = GroovyMock(SuPerson) {
+      1 * addMailLocalAddress(*_) >> mailLocalAddresses
+    }
     SuPersonQuery.getSuPersonFromUID(_, uid) >> suPerson
 
     when:
     def resp = service.addMailLocalAddresses(uid, mailLocalAddresses as String[], new SvcAudit())
 
     then:
-    resp == ["kaka@su.se", "bar@su.se", "barbar@su.se"]
+    resp instanceof String[]
   }
 
 }

--- a/src/test/groovy/se/su/it/svc/ldap/SuPersonSpec.groovy
+++ b/src/test/groovy/se/su/it/svc/ldap/SuPersonSpec.groovy
@@ -8,6 +8,7 @@ import se.su.it.svc.commons.SvcUidPwd
 import se.su.it.svc.manager.Config
 import se.su.it.svc.query.SuPersonQuery
 import se.su.it.svc.util.GeneralUtils
+import spock.lang.IgnoreRest
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -381,5 +382,52 @@ class SuPersonSpec extends Specification {
     mailRoutingAddress << ["", "mail@su.se"]
     expected << [false, true]
 
+  }
+
+  def "addMailLocalAddresses: When SuPerson doesn't have any mailLocalAddress entries"() {
+    given:
+    def mailLocalAddresses = ['kaka@su.se', "bar@su.se"] as Set
+    SuPerson suPerson = new SuPerson(objectClass:[])
+
+    when:
+    def resp = suPerson.addMailLocalAddress(mailLocalAddresses)
+
+    then:
+    resp == mailLocalAddresses as String[]
+
+    and:
+    suPerson.objectClass.contains('inetLocalMailRecipient')
+  }
+
+  def "addMailLocalAddresses: When SuPerson already has mailLocalAddress entries."() {
+    given:
+    def mailLocalAddresses = ['kaka@su.se', "bar@su.se", "foo@bar.se"] as Set
+    SuPerson suPerson = new SuPerson(objectClass:['inetLocalMailRecipient'])
+    suPerson.@mailLocalAddress = ["barbar@su.se", "kaka@su.se"]
+
+    when:
+    def resp = suPerson.addMailLocalAddress(mailLocalAddresses)
+
+    then:
+    resp == ["kaka@su.se", "bar@su.se", "foo@bar.se", "barbar@su.se"]
+
+    and:
+    suPerson.objectClass.contains('inetLocalMailRecipient')
+  }
+
+  def "addMailLocalAddresses: When no new entries are added objectClass is not set either."() {
+    given:
+    def mailLocalAddresses = ["kaka@su.se"] as Set
+    SuPerson suPerson = new SuPerson()
+    suPerson.@mailLocalAddress = ["kaka@su.se"]
+
+    when:
+    def resp = suPerson.addMailLocalAddress(mailLocalAddresses)
+
+    then:
+    resp == ["kaka@su.se"]
+
+    and:
+    suPerson.objectClass == null
   }
 }


### PR DESCRIPTION
Moved addMailLocalAddress closer to the domain model. Reusing overriden method for setting proper objectClass when initializing SuPerson with mailLocalAddress.
