### PR TITLE
INC-1086556: Allow 11 chars long uids

### DIFF
--- a/src/main/groovy/se/su/it/svc/commons/LdapAttributeValidator.groovy
+++ b/src/main/groovy/se/su/it/svc/commons/LdapAttributeValidator.groovy
@@ -76,8 +76,8 @@ public class LdapAttributeValidator {
     if (! (uid ==~ /^[a-z0-9]*$/))
       throwMe(validateAttributesString,"Attribute validation failed for uid <${uid}>. Only alphanumeric characters are allowed.")
 
-    if (! (uid ==~ /^.{2,10}$/))
-      throwMe(validateAttributesString,"Attribute validation failed for uid <${uid}>. uid:s are between 2 and 10 chars in length.")
+    if (! (uid ==~ /^.{2,11}$/))
+      throwMe(validateAttributesString,"Attribute validation failed for uid <${uid}>. uid:s are between 2 and 11 chars in length.")
   }
 
   private static void validateAffiliations(Object affiliations) {

--- a/src/test/groovy/se/su/it/svc/commons/LdapAttributeValidatorSpec.groovy
+++ b/src/test/groovy/se/su/it/svc/commons/LdapAttributeValidatorSpec.groovy
@@ -24,10 +24,11 @@ class LdapAttributeValidatorSpec extends Specification
         noExceptionThrown()
 
         where:
-        uid          | _
-        "validuid"   | _
-        "042larkar"  | _
-        "0123456789" | _
+        uid           | _
+        "validuid"    | _
+        "042larkar"   | _
+        "0123456789"  | _
+        "01234567890" | _
     }
 
     @Unroll
@@ -40,12 +41,12 @@ class LdapAttributeValidatorSpec extends Specification
         thrown(IllegalArgumentException)
 
         where:
-        uid           | _
-        null          | _
-        "a"           | _
-        "01234567890" | _
-        "a-b"         | _
-        [1: "foo"]    | _
+        uid            | _
+        null           | _
+        "a"            | _
+        "012345678901" | _
+        "a-b"          | _
+        [1: "foo"]     | _
     }
 
     def "checkValidMailAddress: email patterns"()


### PR DESCRIPTION
There are some uids in SUKAT that are longer than 10 chars. Maybe
this limit should be 8, but that would require some excessive
cleanup and is therefor save for a rainy day.