### PR TITLE
IDM-1864: Fix card order querys

### DIFF
--- a/src/main/groovy/se/su/it/svc/query/SuCardOrderQuery.groovy
+++ b/src/main/groovy/se/su/it/svc/query/SuCardOrderQuery.groovy
@@ -59,7 +59,7 @@ class SuCardOrderQuery {
   public static final findAllCardsQuery = "SELECT r.id, r.serial, r.owner, r.printer, " +
       "r.createTime, r.firstname, r.lastname, a.streetaddress1, " +
       "a.streetaddress2, a.locality, a.zipcode, s.value, s.description " +
-      "FROM request r JOIN address a ON r.address = a.id" +
+      "FROM request r LEFT JOIN address a ON r.address = a.id" +
       " JOIN status s ON r.status = s.id WHERE r.owner = :uid"
 
   /**
@@ -67,7 +67,7 @@ class SuCardOrderQuery {
    */
   public static final findActiveCardOrdersQuery = "SELECT r.id, serial, owner, printer, createTime, firstname, " +
       "lastname, streetaddress1, streetaddress2, locality, zipcode, value, description " +
-      "FROM request r JOIN address a ON r.address = a.id " +
+      "FROM request r LEFT JOIN address a ON r.address = a.id " +
       "JOIN status s ON r.status = s.id WHERE r.owner = :owner AND status in (1,2,3)"
 
   /**

--- a/src/test/groovy/se/su/it/svc/query/SuCardOrderQuerySpec.groovy
+++ b/src/test/groovy/se/su/it/svc/query/SuCardOrderQuerySpec.groovy
@@ -71,7 +71,7 @@ public class SuCardOrderQuerySpec extends Specification {
   void "getFindAllCardsQuery"() {
     expect: 'should return'
     service.findAllCardsQuery == "SELECT r.id, r.serial, r.owner, r.printer, r.createTime, r.firstname, r.lastname, a.streetaddress1," +
-        " a.streetaddress2, a.locality, a.zipcode, s.value, s.description FROM request r JOIN address a " +
+        " a.streetaddress2, a.locality, a.zipcode, s.value, s.description FROM request r LEFT JOIN address a " +
         "ON r.address = a.id JOIN status s ON r.status = s.id WHERE r.owner = :uid"
   }
 
@@ -196,7 +196,7 @@ public class SuCardOrderQuerySpec extends Specification {
 
   void "getFindActiveCardOrdersQuery"() {
     expect:
-    service.findActiveCardOrdersQuery == "SELECT r.id, serial, owner, printer, createTime, firstname, lastname, streetaddress1, streetaddress2, locality, zipcode, value, description FROM request r JOIN address a ON r.address = a.id JOIN status s ON r.status = s.id WHERE r.owner = :owner AND status in (1,2,3)"
+    service.findActiveCardOrdersQuery == "SELECT r.id, serial, owner, printer, createTime, firstname, lastname, streetaddress1, streetaddress2, locality, zipcode, value, description FROM request r LEFT JOIN address a ON r.address = a.id JOIN status s ON r.status = s.id WHERE r.owner = :owner AND status in (1,2,3)"
   }
 
   void "getFindFreeUUIDQuery"() {


### PR DESCRIPTION
Since address is null for locally printed cards and older cards
that where imported from SUKAT this needs to use a LEFT JOIN
instead of default INNER JOIN.