### PR TITLE
IDM-1472: Extend protection aginst duplicate uid

### DIFF
--- a/src/main/groovy/se/su/it/svc/AccountServiceImpl.groovy
+++ b/src/main/groovy/se/su/it/svc/AccountServiceImpl.groovy
@@ -47,7 +47,10 @@ import se.su.it.svc.commons.SvcUidPwd
 import se.su.it.svc.ldap.SuPerson
 import se.su.it.svc.ldap.SuPersonStub
 import se.su.it.svc.manager.ConfigManager
+
+import se.su.it.svc.query.AccountQuery
 import se.su.it.svc.query.SuPersonQuery
+
 import se.su.it.svc.server.annotations.AuditHideReturnValue
 import se.su.it.svc.server.annotations.AuthzRole
 import se.su.it.svc.util.AccountServiceUtils
@@ -333,6 +336,11 @@ public class AccountServiceImpl implements AccountService
           @WebParam(name = 'givenName') String givenName,
           @WebParam(name = 'sn') String sn
   ) {
+
+        if (AccountQuery.findAccountByUid(ConfigManager.LDAP_RW, uid))
+        {
+            throw new IllegalArgumentException("createSuPerson - An account with uid <" + uid + "> already exists")
+        }
 
     if (SuPersonQuery.findSuPersonByUID(ConfigManager.LDAP_RW, uid)) {
       throw new IllegalArgumentException("createSuPerson - A user with uid <"+uid+"> already exists")

--- a/src/main/groovy/se/su/it/svc/ldap/Account.groovy
+++ b/src/main/groovy/se/su/it/svc/ldap/Account.groovy
@@ -1,0 +1,12 @@
+package se.su.it.svc.ldap
+
+import gldapo.schema.annotation.GldapoNamingAttribute
+import gldapo.schema.annotation.GldapoSchemaFilter
+
+@GldapoSchemaFilter("(objectClass=account)")
+class Account
+{
+    @GldapoNamingAttribute
+    String uid
+}
+

--- a/src/main/groovy/se/su/it/svc/query/AccountQuery.groovy
+++ b/src/main/groovy/se/su/it/svc/query/AccountQuery.groovy
@@ -1,0 +1,24 @@
+package se.su.it.svc.query
+
+import se.su.it.svc.ldap.Account
+
+public class AccountQuery
+{
+    /**
+    * Returns an Account object, specified by the parameter uid.
+    *
+    * @param directory which directory to use, see ConfigManager.
+    * @param uid  the uid (user id) for the user that you want to find.
+    * @return an <code><Account></code> or null.
+    * @see se.su.it.svc.ldap.Account
+    * @see se.su.it.svc.manager.ConfigManager
+    */
+    static Account findAccountByUid(String directory, String uid)
+    {
+        return Account.find(
+            directory: directory,
+            filter: "(uid=${uid})"
+        )
+    }
+}
+

--- a/src/main/resources/defaultApplicationConfig.groovy
+++ b/src/main/resources/defaultApplicationConfig.groovy
@@ -85,6 +85,7 @@ directories {
   }
 }
 schemas = [
+    se.su.it.svc.ldap.Account,
     se.su.it.svc.ldap.SuPersonStub,
     se.su.it.svc.ldap.SuRole,
     se.su.it.svc.ldap.SuCard,

--- a/src/test/groovy/se/su/it/svc/AccountServiceImplSpec.groovy
+++ b/src/test/groovy/se/su/it/svc/AccountServiceImplSpec.groovy
@@ -40,9 +40,14 @@ import se.su.it.commons.PasswordUtils
 import se.su.it.svc.commons.SvcPostalAddressVO
 import se.su.it.svc.commons.SvcSuPersonVO
 import se.su.it.svc.commons.SvcUidPwd
+
+import se.su.it.svc.ldap.Account
 import se.su.it.svc.ldap.SuPerson
 import se.su.it.svc.ldap.SuPersonStub
+
+import se.su.it.svc.query.AccountQuery
 import se.su.it.svc.query.SuPersonQuery
+
 import se.su.it.svc.util.AccountServiceUtils
 import se.su.it.svc.util.GeneralUtils
 import spock.lang.Shared
@@ -371,8 +376,22 @@ class AccountServiceImplSpec extends Specification {
     thrown(PreconditionViolation)
   }
 
+    def "createSuPerson: account already exist"()
+    {
+        setup:
+        AccountQuery.metaClass.static.findAccountByUid = { String directory, String uid -> new Account() }
+        def accountServiceImpl = new AccountServiceImpl()
+
+        when:
+        accountServiceImpl.createSuPerson("testtest", "6601010357", "Test", "Testsson")
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
   def "Test createSuPerson with already exist uid argument"() {
     setup:
+    AccountQuery.metaClass.static.findAccountByUid = { String directory, String uid -> null }
     SuPersonQuery.metaClass.static.findSuPersonByUID = {String directory,String uid -> new SuPerson() }
     def accountServiceImpl = new AccountServiceImpl()
 
@@ -407,6 +426,7 @@ class AccountServiceImplSpec extends Specification {
 
   def "createSuPerson: socialSecurityNumber already exists"() {
     setup:
+    AccountQuery.metaClass.static.findAccountByUid = { String directory, String uid -> null }
     SuPersonQuery.metaClass.static.findSuPersonByUID = {String directory,String uid -> null }
     SuPersonQuery.metaClass.static.getSuPersonFromSsn = {String directory,String uid -> new SuPerson() }
     def accountServiceImpl = new AccountServiceImpl()

--- a/src/test/groovy/se/su/it/svc/query/AccountQuerySpec.groovy
+++ b/src/test/groovy/se/su/it/svc/query/AccountQuerySpec.groovy
@@ -1,0 +1,34 @@
+package se.su.it.svc.query
+
+import gldapo.GldapoSchemaRegistry
+
+import se.su.it.svc.ldap.Account
+
+import spock.lang.Specification
+
+class AccountQuerySpec extends Specification
+{
+    def setup()
+    {
+        GldapoSchemaRegistry.metaClass.add = { Object registration -> }
+    }
+
+    def cleanup()
+    {
+        Account.metaClass = null
+        GldapoSchemaRegistry.metaClass = null
+    }
+
+    def "findAccountByUid: no account is found"()
+    {
+        given:
+        GroovyMock(Account, global:true)
+        Account.find(*_) >> { return null }
+
+        when:
+        def resp = AccountQuery.findAccountByUid(null, null)
+
+        then:
+        resp == null
+    }
+}


### PR DESCRIPTION
In SUKAT there are also service accounts and placeholders for bad
uids and removed accounts, this ensure that we don't create
duplicate uids.