### PR TITLE
IDM-1847: Revert logic in addMailLocalAddress

### DIFF
--- a/src/main/groovy/se/su/it/svc/ldap/SuPerson.groovy
+++ b/src/main/groovy/se/su/it/svc/ldap/SuPerson.groovy
@@ -331,17 +331,17 @@ class SuPerson implements Serializable {
 
         mailLocalAddresses = mailLocalAddresses*.toLowerCase()
 
-        if (mailLocalAddress == null)
-        {
-            setMailLocalAddress(mailLocalAddresses)
-        }
-        else
+        if (mailLocalAddress)
         {
             def newEntries = mailLocalAddresses - mailLocalAddress*.toLowerCase()
             if (newEntries)
             {
                 mailLocalAddress += newEntries
             }
+        }
+        else
+        {
+            setMailLocalAddress(mailLocalAddresses)
         }
 
         return mailLocalAddress as String[]

--- a/src/main/groovy/se/su/it/svc/ldap/SuPerson.groovy
+++ b/src/main/groovy/se/su/it/svc/ldap/SuPerson.groovy
@@ -322,25 +322,30 @@ class SuPerson implements Serializable {
     log.info("enrollUser - User with uid <$uid> now enabled.")
   }
 
-  /**
-   * Sets mailLocalAddress if not already set, adds new mailLocalAddress if
-   * @param mailLocalAddresses
-   */
-  public String[] addMailLocalAddress(Set<String> mailLocalAddresses) {
+    /**
+     * Sets mailLocalAddress if not already set, adds new mailLocalAddress if
+     * @param mailLocalAddresses
+     */
+    public String[] addMailLocalAddress(Set<String> mailLocalAddresses)
+    {
 
-    mailLocalAddresses = mailLocalAddresses*.toLowerCase()
+        mailLocalAddresses = mailLocalAddresses*.toLowerCase()
 
-    if (mailLocalAddress == null) {
-      setMailLocalAddress(mailLocalAddresses)
-    } else {
-      def newEntries = mailLocalAddresses - mailLocalAddress*.toLowerCase()
-      if (newEntries) {
-        mailLocalAddress += newEntries
-      }
+        if (mailLocalAddress == null)
+        {
+            setMailLocalAddress(mailLocalAddresses)
+        }
+        else
+        {
+            def newEntries = mailLocalAddresses - mailLocalAddress*.toLowerCase()
+            if (newEntries)
+            {
+                mailLocalAddress += newEntries
+            }
+        }
+
+        return mailLocalAddress as String[]
     }
-
-    return mailLocalAddress as String[]
-  }
 
   private boolean isSkipCreateEnabled() {
     return configManager.config.enrollment.create.skip == "true"

--- a/src/test/groovy/se/su/it/svc/ldap/SuPersonSpec.groovy
+++ b/src/test/groovy/se/su/it/svc/ldap/SuPersonSpec.groovy
@@ -400,7 +400,7 @@ class SuPersonSpec extends Specification {
   def "addMailLocalAddresses: When SuPerson doesn't have any mailLocalAddress entries"() {
     given:
     def mailLocalAddresses = ['kaka@su.se', "bar@su.se"] as Set
-    SuPerson suPerson = new SuPerson(objectClass:[])
+    SuPerson suPerson = new SuPerson(objectClass: [], mailLocalAddress: [])
 
     when:
     def resp = suPerson.addMailLocalAddress(mailLocalAddresses)


### PR DESCRIPTION
Gldapo will initialize Set<String> mailLocalAddress to [], this
is not null and therefor the test will always be false. Revert
the logic to check for presense, this will handle both null and
[]. Also update unit test to check the [] case.