### PR TITLE
IDM-2090: Send message to SUKAT consumers on activation

### DIFF
--- a/src/main/groovy/se/su/it/svc/AccountServiceImpl.groovy
+++ b/src/main/groovy/se/su/it/svc/AccountServiceImpl.groovy
@@ -427,10 +427,16 @@ public class AccountServiceImpl implements AccountService
     suPerson.activate(svcUidPwd, affiliations, domain)
 
     // Notify Ladok-import of the activation to setup postaladdress and more
-    def msg = [:]
-    msg.socialsecuritynumber = GeneralUtils.ssnToNin(suPerson.socialSecurityNumber)
+    def ladokMsg = [:]
+    ladokMsg.socialsecuritynumber = GeneralUtils.ssnToNin(suPerson.socialSecurityNumber)
 
-    GeneralUtils.publishMessage(msg)
+    GeneralUtils.publishMessage(ladokMsg)
+
+    // Notify SUKAT consumers of new account (mostly AD sync)
+    def sukatMsg = [:]
+    sukatMsg.update = suPerson.uid
+
+    GeneralUtils.publishMessage(sukatMsg)
 
     return svcUidPwd
   }

--- a/src/test/groovy/se/su/it/svc/AccountServiceImplSpec.groovy
+++ b/src/test/groovy/se/su/it/svc/AccountServiceImplSpec.groovy
@@ -773,7 +773,7 @@ class AccountServiceImplSpec extends Specification {
     then:
     svcUidPwd.uid == 'uid'
     svcUidPwd.password.size() == 10
-    1 * GeneralUtils.publishMessage(*_)
+    2 * GeneralUtils.publishMessage(*_)
   }
 
   def "activateSuPerson: test when user doesn't exist in LDAP, should throw exception"() {
@@ -823,7 +823,7 @@ class AccountServiceImplSpec extends Specification {
     ret.uid == uid
     ret.password == password
     1 * PasswordUtils.genRandomPassword(10, 10) >> password
-    1 * GeneralUtils.publishMessage(*_)
+    2 * GeneralUtils.publishMessage(*_)
   }
 
   def "addMailLocalAddresses: given no valid uid"() {


### PR DESCRIPTION
Mostly helps AD-sync got get information in quickly so that
mailboxes and the like can be created