### PR TITLE
MARVAL-1448707: Add type

### DIFF
--- a/src/main/groovy/se/su/it/svc/AccountServiceImpl.groovy
+++ b/src/main/groovy/se/su/it/svc/AccountServiceImpl.groovy
@@ -248,7 +248,7 @@ public class AccountServiceImpl implements AccountService
 
         def directory = ConfigManager.LDAP_RW
 
-        def suPersonStub = SuPersonStub.newInstance(uid, givenName, sn, ssn, parent, directory)
+        SuPersonStub suPersonStub = SuPersonStub.newInstance(uid, givenName, sn, ssn, parent, directory)
 
         suPersonStub.save()
 


### PR DESCRIPTION
Hopefullt this will solve intermittent missingMethod excetptions.

No signature of method: java.lang.String.createEntry() is applicable for
argument types: (org.springframework.ldap.core.DistinguishedName,
javax.naming.directory.BasicAttributes)